### PR TITLE
Update format for sctplb.yaml

### DIFF
--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -420,10 +420,11 @@ config:
           dispatcherLogs: info
           clientdiscLogs: info
         configuration:
-          serviceNames:
-          - "amf-headless"
+          type: "grpc"
+          services:
+            - uri: "amf-headless"
           ngapIpList:
-            - "0.0.0.0"
+            - 0.0.0.0
   amf:
     deploy: true
     # serviceAnnotations:


### PR DESCRIPTION
When the `stcplb` code/repo was refactored, the format for its configuration file (`sctplb.yaml`) changed as it can be seen [here](https://github.com/omec-project/sctplb/pull/8/files#diff-35d367725c2233db162dd170d5a65186f6f6ce998fd21c6da4e4a914a2efd47f). This PR updates the values.yaml file in the Helm Charts to reflect these changes.