### PR TITLE
Update references to JSONC instead of JSON

### DIFF
--- a/bess-upf/templates/statefulset-upf.yaml
+++ b/bess-upf/templates/statefulset-upf.yaml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 */}}
 
-{{- $upfConfig := index .Values.config.upf.cfgFiles "upf.json" }}
+{{- $upfConfig := index .Values.config.upf.cfgFiles "upf.jsonc" }}
 {{- $accessConfig := index $upfConfig "access" }}
 {{- $coreConfig := index $upfConfig "core" }}
 ---
@@ -142,7 +142,7 @@ spec:
           {{- end }}
         env:
           - name: CONF_FILE
-            value: /etc/bess/conf/upf.json
+            value: /etc/bess/conf/upf.jsonc
         volumeMounts:
           - name: shared-app
             mountPath: /pod-share
@@ -185,7 +185,7 @@ spec:
         command: ["pfcpiface"]
         args:
           - -config
-          - /tmp/conf/upf.json
+          - /tmp/conf/upf.jsonc
       {{- if .Values.resources.enabled }}
         resources:
 {{ toYaml .Values.resources.cpiface | indent 10 }}

--- a/bess-upf/values.yaml
+++ b/bess-upf/values.yaml
@@ -93,7 +93,7 @@ config:
       #vlan:
       #iface:
     cfgFiles:
-      upf.json:
+      upf.jsonc:
         mode: dpdk
         workers: 1
         max_sessions: 50000

--- a/sdcore-helm-charts/values.yaml
+++ b/sdcore-helm-charts/values.yaml
@@ -24,7 +24,7 @@ omec-user-plane:
   #config:
   #  upf:
   #    cfgFiles:
-  #      upf.json:
+  #      upf.jsonc:
   #        cpiface:
 
 omec-sub-provision:


### PR DESCRIPTION
As per the changes made in the UPF repo (https://github.com/omec-project/upf/pull/702), this PR updates configuration file name for the UPF to `upf.jsonc` instead of `upf.json`