### PR TITLE
Updates into BESS-UPF charts

### DIFF
--- a/bess-upf/templates/statefulset-upf.yaml
+++ b/bess-upf/templates/statefulset-upf.yaml
@@ -55,8 +55,8 @@ spec:
     {{- end }}
       initContainers:
       - name: bess-init
-        image: {{ .Values.images.tags.bess | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.bess }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         command: ["sh", "-xec"]
         args:
         - ip route replace {{ .Values.config.upf.enb.subnet }} via {{ .Values.config.upf.access.gateway }};
@@ -81,8 +81,8 @@ spec:
     {{- end }}
       containers:
       - name: bessd
-        image: {{ .Values.images.tags.bess | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.bess }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         securityContext:
         {{- if .Values.config.upf.privileged }}
           privileged: true
@@ -157,8 +157,8 @@ spec:
             mountPath: /tmp/coredump
         {{- end }}
       - name: routectl
-        image: {{ .Values.images.tags.bess | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.bess }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         env:
           - name: PYTHONUNBUFFERED
             value: "1"
@@ -172,16 +172,16 @@ spec:
 {{ toYaml .Values.resources.routectl | indent 10 }}
       {{- end }}
       - name: web
-        image: {{ .Values.images.tags.bess | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.bess }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         command: ["/bin/bash", "-xc", "bessctl http 0.0.0.0 8000"]
       {{- if .Values.resources.enabled }}
         resources:
 {{ toYaml .Values.resources.web | indent 10 }}
       {{- end }}
       - name: pfcp-agent
-        image: {{ .Values.images.tags.pfcpiface | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.pfcpiface }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         command: ["pfcpiface"]
         args:
           - -config
@@ -197,8 +197,8 @@ spec:
             mountPath: /tmp/conf
     {{- if .Values.config.gratuitousArp.enabled }}
       - name: arping
-        image: {{ .Values.images.tags.tools | quote }}
-        imagePullPolicy: {{ .Values.images.pullPolicy | quote }}
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.tools }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
         command: ["sh", "-xc"]
         args:
           - |

--- a/bess-upf/values.yaml
+++ b/bess-upf/values.yaml
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 images:
+  repository: "" #default docker hub
   tags:
-    bess: "omecproject/upf-epc-bess:master-5786085"
-    pfcpiface: "omecproject/upf-epc-pfcpiface:master-5786085"
-    tools: registry.aetherproject.org/tools/busybox:stable
+    bess: omecproject/upf-epc-bess:master-5786085
+    pfcpiface: omecproject/upf-epc-pfcpiface:master-5786085
+    tools: busybox:stable
   pullPolicy: IfNotPresent
   # Secrets must be manually created in the namespace.
   pullSecrets:


### PR DESCRIPTION
This PRs includes two changes/improvements:
- Adds repository component (path) to images, and
- Removes redundant "quote" component from `image` and `imagePullPolicy`

Changes in this PRs were tested with the latest images for all of the 5GC components using an E2E test with AiaB