### PR TITLE
Store authentication keys in a separate database

### DIFF
--- a/5g-control-plane/templates/configmap-udr.yaml
+++ b/5g-control-plane/templates/configmap-udr.yaml
@@ -12,7 +12,7 @@
 {{- $sbi := index $config "sbi" }}
 
 {{- if not (hasKey $config "mongodb") -}}
-{{- $_ := dict "name" .Values.config.mongodb.name "url" .Values.config.mongodb.url | set $config "mongodb" -}}
+{{- $_ := dict "name" .Values.config.mongodb.name "url" .Values.config.mongodb.url "authKeysDbName" .Values.config.mongodb.authKeysDbName "authUrl" .Values.config.mongodb.authUrl | set $config "mongodb" -}}
 {{- end }}
 
 {{- if not (hasKey $udrcfg "logger") -}}

--- a/5g-control-plane/templates/configmap-webui.yaml
+++ b/5g-control-plane/templates/configmap-webui.yaml
@@ -19,7 +19,7 @@
 {{- end }}
 
 {{- if not (hasKey $config "mongodb") -}}
-{{- $_ := dict "name" .Values.config.mongodb.name "url" .Values.config.mongodb.url | set $config "mongodb" -}}
+{{- $_ := dict "name" .Values.config.mongodb.name "url" .Values.config.mongodb.url "authKeysDbName" .Values.config.mongodb.authKeysDbName "authUrl" .Values.config.mongodb.authUrl | set $config "mongodb" -}}
 {{- end }}
 
 {{- end }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -147,6 +147,8 @@ config:
   mongodb:
     name: free5gc
     url: mongodb://mongodb-arbiter-headless
+    authKeysDbName: authentication
+    authUrl: mongodb://mongodb-arbiter-headless
   grpc:
     golog_verbosity: "99"
     severity: "info"


### PR DESCRIPTION
The changes here required for the PRs in [udr #63](https://github.com/omec-project/udr/pull/63) and [webconsole #132](https://github.com/omec-project/webconsole) about storing authentication keys in a separate database to work. These 3 PRs need to be merged together.