### PR TITLE
Create a service for the API endpoint of the metricfunc pod.

### DIFF
--- a/5g-control-plane/templates/service-metricfunc.yaml
+++ b/5g-control-plane/templates/service-metricfunc.yaml
@@ -25,4 +25,12 @@ spec:
     nodePort: {{ .Values.config.metricfunc.prometheus.nodePort }}
 {{- end }}
 {{- end }}
+  - name: api-endpoint
+    port: {{ .Values.config.metricfunc.apiEndpoint.port }}
+    protocol: TCP
+{{- if eq .Values.config.metricfunc.serviceType "NodePort" }}
+{{- if .Values.config.metricfunc.apiEndpoint.nodePort }}
+    nodePort: {{ .Values.config.metricfunc.apiEndpoint.nodePort }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -700,6 +700,8 @@ config:
     serviceType: ClusterIP
     prometheus:
       port: 9089
+    apiEndpoint:
+      port: 9301
     cfgFiles:
       metricscfg.conf:
         configuration:


### PR DESCRIPTION
This PR allows for the [API endpoints of the metricfunc pod](https://docs.sd-core.opennetworking.org/master/design/design-metricfunc.html) to be reachable via a Service endpoint, instead of the pod-ip address.