### PR TITLE
Improve Charts file to directly point to dependencies (file://) instead of using links (https://)

### DIFF
--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.1
+version: 1.0.2
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -19,31 +19,26 @@ maintainers:
 dependencies:
   - name: omec-control-plane
     version: 0.13.0
-    repository: https://charts.aetherproject.org
-    #repository: "file://../omec-control-plane"
+    repository: "file://../omec-control-plane"
     condition: omec-control-plane.enable4G
 
   - name: omec-sub-provision
     version: 1.0.0
-    repository: https://charts.aetherproject.org
-    #repository: "file://../omec-sub-provision"
+    repository: "file://../omec-sub-provision"
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
     version: 1.0.1
-    repository: https://charts.aetherproject.org
-    #repository: "file://../5g-control-plane"
+    repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 
   - name: bess-upf
     version: 1.0.0
-    repository: https://charts.aetherproject.org
-    #repository: "file://../bess-upf"
+    repository: "file://../bess-upf"
     alias: omec-user-plane
     condition: omec-user-plane.enable
 
   - name: 5g-ran-sim
     version: 1.0.0
-    repository: https://charts.aetherproject.org
-    #repository: "file://../5g-ran-sim"
+    repository: "file://../5g-ran-sim"
     condition: 5g-ran-sim.enable


### PR DESCRIPTION
This PR makes things easier when using local Helm Charts and it is compatible to when using "online" Helm Charts (from https://charts.aetherproject.org/).
This PR follows the same implementation as it was done in the SD-RAN Helm Charts (https://github.com/onosproject/sdran-helm-charts/blob/master/sd-ran/Chart.yaml)