### PR TITLE
Add nodeSelectors to 5G control plane charts

### DIFF
--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -10,7 +10,7 @@ description: SD-Core 5G control plane services
 name: 5g-control-plane
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   - name: mongodb

--- a/5g-control-plane/templates/deployment-amf.yaml
+++ b/5g-control-plane/templates/deployment-amf.yaml
@@ -28,6 +28,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: amf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -64,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-ausf.yaml
+++ b/5g-control-plane/templates/deployment-ausf.yaml
@@ -31,6 +31,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: ausf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -68,7 +72,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-metricfunc.yaml
+++ b/5g-control-plane/templates/deployment-metricfunc.yaml
@@ -28,6 +28,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: metricfunc
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}

--- a/5g-control-plane/templates/deployment-nrf.yaml
+++ b/5g-control-plane/templates/deployment-nrf.yaml
@@ -31,6 +31,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: nrf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -64,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-nssf.yaml
+++ b/5g-control-plane/templates/deployment-nssf.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: nssf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -66,7 +70,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-pcf.yaml
+++ b/5g-control-plane/templates/deployment-pcf.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: pcf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -66,7 +70,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-sctplb.yaml
+++ b/5g-control-plane/templates/deployment-sctplb.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: sctplb
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}

--- a/5g-control-plane/templates/deployment-smf.yaml
+++ b/5g-control-plane/templates/deployment-smf.yaml
@@ -31,6 +31,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: smf
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -73,7 +77,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-udm.yaml
+++ b/5g-control-plane/templates/deployment-udm.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: udm
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -70,7 +74,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-udr.yaml
+++ b/5g-control-plane/templates/deployment-udr.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: udr
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
@@ -66,7 +70,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
       {{- if .Values.config.managedByConfigPod.enabled }}
-        - name: MANAGED_BY_CONFIG_POD 
+        - name: MANAGED_BY_CONFIG_POD
           value: "true"
       {{- end }}
       {{- if .Values.resources.enabled }}

--- a/5g-control-plane/templates/deployment-upf-adapter.yaml
+++ b/5g-control-plane/templates/deployment-upf-adapter.yaml
@@ -29,6 +29,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: upfadapter
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}

--- a/5g-control-plane/templates/deployment-webui.yaml
+++ b/5g-control-plane/templates/deployment-webui.yaml
@@ -28,6 +28,10 @@ spec:
     {{- end }}
     spec:
       serviceAccountName: webui
+    {{- if .Values.nodeSelectors.enabled }}
+      nodeSelector:
+        {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
+    {{- end }}
     {{- if hasKey .Values.images "pullSecrets" }}
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -21,6 +21,11 @@ images:
     upfadapter: omecproject/5gc-smf:rel-1.4.0
   pullPolicy: IfNotPresent
 
+nodeSelectors:
+  enabled: false
+  label: node-role.aetherproject.org
+  value: 5gc
+
 resources:
   enabled: false
   sctplb:

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.2
+version: 1.0.3
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -28,7 +28,7 @@ dependencies:
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
-    version: 1.0.1
+    version: 1.0.2
     repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 


### PR DESCRIPTION
- NodeSelector capability is disabled by default
- All control plane components use the same node selector. That is, when nodeSelector is enabled, all CP components will get deployed in the same node(s) based on a single nodeSelector
- Tested changes using OnRamp with local Helm Charts, as shown below:

![image](https://github.com/omec-project/sdcore-helm-charts/assets/87488727/7ca98267-60c6-4170-b3b3-2dfbc468a156)
