### PR TITLE
Add `allow` option to limit DPDK to use the assigned ports

### DIFF
--- a/bess-upf/templates/statefulset-upf.yaml
+++ b/bess-upf/templates/statefulset-upf.yaml
@@ -95,11 +95,13 @@ spec:
         tty: true
         command: ["/bin/bash", "-xc"]
         args:
-        {{- if .Values.config.upf.hugepage.enabled }}
-          - bessd -f -grpc-url=0.0.0.0:10514
-        {{- else }}
-          - bessd -m 0 -f -grpc-url=0.0.0.0:10514
-        {{- end }}
+          - |
+            VFS=$(ip link | grep -E 'alias [0-9a-f:.]+' | awk '{print $2}' | tr '\n' ',');
+          {{- if .Values.config.upf.hugepage.enabled }}
+            bessd -f --allow="$VFS" --grpc_url=0.0.0.0:10514;
+          {{- else }}
+            bessd -m 0 -f --allow="$VFS" --grpc_url=0.0.0.0:10514;
+          {{- end }}
         lifecycle:
           postStart:
             exec:


### PR DESCRIPTION
This PR is important when deploying multiple UPF instances (DPDK mode) in the same host. These changes make scalable the deployment of multiple UPFs (DPDK mode) in the same host.
It only takes "effect" when deploying the UPF in DPDK mode and when the interface(s) has/have the PCI address as its alias. Otherwise, everything works as it has been working as of before this patch/PR