### PR TITLE
Improved solution to pass PCI address to BESS when UPF is deployed in DPDK mode

### DIFF
--- a/bess-upf/Chart.yaml
+++ b/bess-upf/Chart.yaml
@@ -7,4 +7,4 @@ description: OMEC user plane based on BESS
 name: bess-upf
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.0
+version: 1.0.1

--- a/bess-upf/templates/statefulset-upf.yaml
+++ b/bess-upf/templates/statefulset-upf.yaml
@@ -95,13 +95,11 @@ spec:
         tty: true
         command: ["/bin/bash", "-xc"]
         args:
-          - |
-            VFS=$(ip link | grep -E 'alias [0-9a-f:.]+' | awk '{print $2}' | tr '\n' ',');
-          {{- if .Values.config.upf.hugepage.enabled }}
-            bessd -f --allow="$VFS" --grpc_url=0.0.0.0:10514;
-          {{- else }}
-            bessd -m 0 -f --allow="$VFS" --grpc_url=0.0.0.0:10514;
-          {{- end }}
+        {{- if .Values.config.upf.hugepage.enabled }}
+          - bessd -f --allow="$PCIDEVICE_INTEL_COM_INTEL_SRIOV_DPDK" --grpc_url=0.0.0.0:10514
+        {{- else }}
+          - bessd -m 0 -f --allow="$PCIDEVICE_INTEL_COM_INTEL_SRIOV_DPDK" --grpc_url=0.0.0.0:10514
+        {{- end }}
         lifecycle:
           postStart:
             exec:

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     condition: 5g-control-plane.enable5G
 
   - name: bess-upf
-    version: 1.0.0
+    version: 1.0.1
     repository: "file://../bess-upf"
     alias: omec-user-plane
     condition: omec-user-plane.enable


### PR DESCRIPTION
This PR is an improvement to PR #30 that instead of getting the PCI address from the interface (alias), it will directly get it from the environment variable `PCIDEVICE_INTEL_COM_INTEL_SRIOV_DPDK`, which will be present only when the UPF is deployed in DPDK mode. Otherwise, `allow` will be empty and will have no effect in the other UPF's deployment modes.