### PR TITLE
Use newer helm charts versions for kafka and mongodb

### DIFF
--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -10,15 +10,15 @@ description: SD-Core 5G control plane services
 name: 5g-control-plane
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.3
+version: 1.0.4
 
 dependencies:
   - name: mongodb
-    version: 13.6.4
+    version: 13.16.4
     repository: https://charts.bitnami.com/bitnami
     condition: mongodb.deploy
   - name: kafka
-    version: 20.0.4
+    version: 23.0.7
     repository: https://charts.bitnami.com/bitnami
     condition: kafka.deploy
 

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.4
+version: 1.0.5
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -28,7 +28,7 @@ dependencies:
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
-    version: 1.0.3
+    version: 1.0.4
     repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 


### PR DESCRIPTION
The changes were tested with `OnRamp`

Note: Additional changes are required to be able to use the latest helm charts versions for kafka and mongodb