### PR TITLE
Increased bessd container memory to 2Gi

### DIFF
--- a/bess-upf/Chart.yaml
+++ b/bess-upf/Chart.yaml
@@ -7,4 +7,4 @@ description: OMEC user plane based on BESS
 name: bess-upf
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.4
+version: 1.0.5

--- a/bess-upf/values.yaml
+++ b/bess-upf/values.yaml
@@ -24,10 +24,10 @@ resources:
   bess:
     requests:
       cpu: 2
-      memory: 1Gi
+      memory: 2Gi
     limits:
       cpu: 2
-      memory: 1Gi
+      memory: 2Gi
   routectl:
     requests:
       cpu: 256m

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.8
+version: 1.0.9
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -33,7 +33,7 @@ dependencies:
     condition: 5g-control-plane.enable5G
 
   - name: bess-upf
-    version: 1.0.4
+    version: 1.0.5
     repository: "file://../bess-upf"
     alias: omec-user-plane
     condition: omec-user-plane.enable


### PR DESCRIPTION
Bessd process needs 2Gi minimum memory in order to up and run without any issues. Currently the default value is configured as 1Gi. This will not create issues unless we enable resource flag for the UPF. But when we enable the resource flag (for ex: when we want each POD's to be configured as Guaranteed QoS) the bessd process got killed due to insufficient memory. So the default memory should be configured properly.