### PR TITLE
Handle initial timing issue through init containers

### DIFF
--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -10,7 +10,7 @@ description: SD-Core 5G control plane services
 name: 5g-control-plane
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.11
+version: 1.0.12
 
 dependencies:
   - name: mongodb

--- a/5g-control-plane/templates/deployment-amf.yaml
+++ b/5g-control-plane/templates/deployment-amf.yaml
@@ -36,8 +36,14 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
-      {{- if .Values.config.coreDump.enabled }}
       initContainers:
+      {{- if .Values.kafka.deploy }}
+      - name: wait-kafka-module
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: ['sh', '-c', 'until nslookup kafka; do echo waiting for kafka; sleep 4; done;']
+      {{- end }}
+      {{- if .Values.config.coreDump.enabled }}
       {{ tuple "amf" . | include "5g-control-plane.coredump_init" | indent 6 }}
       {{- end }}
       containers:

--- a/5g-control-plane/templates/deployment-smf.yaml
+++ b/5g-control-plane/templates/deployment-smf.yaml
@@ -40,13 +40,15 @@ spec:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
       initContainers:
-      - name: wait-smf-module
+      {{- if .Values.kafka.deploy }}
+      - name: wait-kafka-module
         image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}
-        command: ['sh', '-c', 'until nslookup smf; do echo waiting for smf; sleep 4; done;']
-    {{- if .Values.config.coreDump.enabled }}
-    {{ tuple "smf" . | include "5g-control-plane.coredump_init" | indent 6 }}
-    {{- end }}
+        command: ['sh', '-c', 'until nslookup kafka; do echo waiting for kafka; sleep 4; done;']
+      {{- end }}
+      {{- if .Values.config.coreDump.enabled }}
+      {{ tuple "smf" . | include "5g-control-plane.coredump_init" | indent 6 }}
+      {{- end }}
       containers:
       - name: smf
         image: {{ .Values.images.repository }}{{ .Values.images.tags.smf }}

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.16
+version: 1.0.17
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -28,7 +28,7 @@ dependencies:
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
-    version: 1.0.11
+    version: 1.0.12
     repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 


### PR DESCRIPTION
SMF & AMF sends the metrics through kafka. Initially SMF & AMF can wait for kafka to comeup. This will help in handling some of the timing issues. This is required because kafka does not have buffering configured. 