### PR TITLE
Changes aligned to the use of `zap` logger in the images

### DIFF
--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -10,7 +10,7 @@ description: SD-Core 5G control plane services
 name: 5g-control-plane
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.13
+version: 1.1.0
 
 dependencies:
   - name: mongodb

--- a/5g-control-plane/templates/bin/_upf-adapter-run.sh.tpl
+++ b/5g-control-plane/templates/bin/_upf-adapter-run.sh.tpl
@@ -7,11 +7,11 @@
 set -xe
 
 {{- if .Values.config.coreDump.enabled }}
-cp /free5gc/bin/upf-adapter /tmp/coredump/
+cp /aether/upfadapter /tmp/coredump/
 {{- end }}
 
-cd /free5gc
+cd /aether
 
 cat config/config.yaml
 
-GOTRACEBACK=crash ./bin/upf-adapter config/config.yaml
+GOTRACEBACK=crash ./upfadapter config/config.yaml

--- a/5g-control-plane/templates/deployment-amf.yaml
+++ b/5g-control-plane/templates/deployment-amf.yaml
@@ -69,6 +69,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-ausf.yaml
+++ b/5g-control-plane/templates/deployment-ausf.yaml
@@ -67,6 +67,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-metricfunc.yaml
+++ b/5g-control-plane/templates/deployment-metricfunc.yaml
@@ -48,6 +48,10 @@ spec:
         tty: true
         command: [ "/metricfunc/script/metricfunc-run.sh" ]
         env:
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-nrf.yaml
+++ b/5g-control-plane/templates/deployment-nrf.yaml
@@ -63,6 +63,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-nssf.yaml
+++ b/5g-control-plane/templates/deployment-nssf.yaml
@@ -65,6 +65,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-pcf.yaml
+++ b/5g-control-plane/templates/deployment-pcf.yaml
@@ -65,6 +65,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-sctplb.yaml
+++ b/5g-control-plane/templates/deployment-sctplb.yaml
@@ -65,6 +65,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-smf.yaml
+++ b/5g-control-plane/templates/deployment-smf.yaml
@@ -72,6 +72,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: PFCP_PORT_UPF
           value: {{ .Values.config.smf.upfPort | quote }}
         - name: POD_IP

--- a/5g-control-plane/templates/deployment-udm.yaml
+++ b/5g-control-plane/templates/deployment-udm.yaml
@@ -69,6 +69,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-udr.yaml
+++ b/5g-control-plane/templates/deployment-udr.yaml
@@ -65,6 +65,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-control-plane/templates/deployment-upf-adapter.yaml
+++ b/5g-control-plane/templates/deployment-upf-adapter.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
         stdin: true
         tty: true
-        command: ["/free5gc/script/upf-adapter-run.sh"]
+        command: ["/aether/script/upf-adapter-run.sh"]
         env:
         - name: POD_IP
           valueFrom:
@@ -59,10 +59,10 @@ spec:
       {{- end }}
         volumeMounts:
         - name: run-script
-          mountPath: /free5gc/script/upf-adapter-run.sh
+          mountPath: /aether/script/upf-adapter-run.sh
           subPath: upf-adapter-run.sh
         - name: upfadapter-config
-          mountPath: /free5gc/config
+          mountPath: /aether/config
       {{- if .Values.config.coreDump.enabled }}
         - name: coredump
           mountPath: /tmp/coredump

--- a/5g-control-plane/templates/deployment-webui.yaml
+++ b/5g-control-plane/templates/deployment-webui.yaml
@@ -56,6 +56,10 @@ spec:
           value: {{ .Values.config.grpc.trace | quote }}
         - name: GRPC_VERBOSITY
           value: {{ .Values.config.grpc.verbosity | quote }}
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: CONFIGPOD_DEPLOYMENT
           value: "5G"
         imagePullPolicy: {{ .Values.images.pullPolicy }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -7,18 +7,18 @@ images:
   repository: "" #default docker hub
   tags:
     init: omecproject/pod-init:1.0.0
-    amf: omecproject/5gc-amf:rel-1.4.5
-    nrf: omecproject/5gc-nrf:rel-1.4.2
-    smf: omecproject/5gc-smf:rel-1.5.3
-    ausf: omecproject/5gc-ausf:rel-1.4.2
-    nssf: omecproject/5gc-nssf:rel-1.4.1
-    pcf: omecproject/5gc-pcf:rel-1.4.4
-    udr: omecproject/5gc-udr:rel-1.4.1
-    udm: omecproject/5gc-udm:rel-1.4.3
-    webui: omecproject/5gc-webui:rel-1.4.3
-    sctplb: omecproject/sctplb:rel-1.4.3
-    metricfunc: omecproject/metricfunc:rel-1.4.1
-    upfadapter: omecproject/5gc-smf:rel-1.5.3
+    amf: omecproject/5gc-amf:rel-1.5.0
+    nrf: omecproject/5gc-nrf:rel-1.5.0
+    smf: omecproject/5gc-smf:rel-1.6.0
+    ausf: omecproject/5gc-ausf:rel-1.5.0
+    nssf: omecproject/5gc-nssf:rel-1.5.0
+    pcf: omecproject/5gc-pcf:rel-1.5.0
+    udr: omecproject/5gc-udr:rel-1.5.0
+    udm: omecproject/5gc-udm:rel-1.5.0
+    webui: omecproject/5gc-webui:rel-1.5.0
+    sctplb: omecproject/sctplb:rel-1.5.0
+    metricfunc: omecproject/metricfunc:rel-1.5.0
+    upfadapter: omecproject/upfadapter:rel-2.0.0
   pullPolicy: IfNotPresent
 
 nodeSelectors:
@@ -155,80 +155,58 @@ config:
     authKeysDbName: authentication
     authUrl: mongodb://mongodb-arbiter-headless
   grpc:
-    golog_verbosity: "99"
+    golog_verbosity: "0"
     severity: "info"
-    trace: "all"
-    verbosity: "debug"
+    trace: "none"
+    verbosity: "none"
+  GIN:
+    mode: release          # Possible options are: release, debug
   logger:
     # network function
     AMF:
       debugLevel: info
-      ReportCaller: false
     SMF:
       debugLevel: info
-      ReportCaller: false
     UDR:
       debugLevel: info
-      ReportCaller: false
     UDM:
       debugLevel: info
-      ReportCaller: false
     NRF:
       debugLevel: info
-      ReportCaller: false
     PCF:
       debugLevel: info
-      ReportCaller: false
     AUSF:
       debugLevel: info
-      ReportCaller: false
     N3IWF:
       debugLevel: info
-      ReportCaller: false
   # library
     NAS:
       debugLevel: info
-      ReportCaller: false
     FSM:
       debugLevel: info
-      ReportCaller: false
     NGAP:
       debugLevel: info
-      ReportCaller: false
-    NamfComm:
+    NamfCommunication:
       debugLevel: info
-      ReportCaller: false
     NamfEventExposure:
       debugLevel: info
-      ReportCaller: false
     NsmfPDUSession:
       debugLevel: info
-      ReportCaller: false
     NudrDataRepository:
       debugLevel: info
-      ReportCaller: false
     OpenApi:
       debugLevel: info
-      ReportCaller: false
     Aper:
       debugLevel: info
-      ReportCaller: false
     CommonConsumerTest:
       debugLevel: info
-      ReportCaller: false
-    PFCP:
+    config5g:
       debugLevel: info
-      ReportCaller: false
     MongoDBLibrary:
       debugLevel: info
-      ReportCaller: false
-    PathUtil:
-      debugLevel: info
-      ReportCaller: false
   # webui
     WEBUI:
       debugLevel: info
-      ReportCaller: false
   webui:
     deploy: true
     #podAnnotations:
@@ -770,4 +748,3 @@ config:
           description: UPF Adapter initial local configuration
         logger:
           level: info
-

--- a/5g-ran-sim/Chart.yaml
+++ b/5g-ran-sim/Chart.yaml
@@ -8,4 +8,4 @@ description: 5G RAN Simulator Service
 name: 5g-ran-sim
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.3
+version: 1.1.0

--- a/5g-ran-sim/templates/statefulset-gnbsim.yaml
+++ b/5g-ran-sim/templates/statefulset-gnbsim.yaml
@@ -74,6 +74,10 @@ spec:
               containerName: gnbsim
               resource: limits.memory
               divisor: 1Mi
+      {{- if eq .Values.config.GIN.mode "release" }}
+        - name: GIN_MODE
+          value: release
+      {{- end }}
         - name: POD_IP
           valueFrom:
             fieldRef:

--- a/5g-ran-sim/values.yaml
+++ b/5g-ran-sim/values.yaml
@@ -6,7 +6,7 @@ images:
   repository: "" #default docker hub
   tags:
     init: omecproject/pod-init:1.0.0
-    gnbsim: omecproject/5gc-gnbsim:rel-1.4.5
+    gnbsim: omecproject/5gc-gnbsim:rel-1.5.0
   pullPolicy: IfNotPresent
 
 nodeSelectors:
@@ -31,6 +31,8 @@ config:
   coreDump:
     enabled: false
     path: /tmp/coredump
+  GIN:
+    mode: release        # Possible options are: release, debug
   gnbsim:
     deploy: true
     waitForAmf: true
@@ -71,7 +73,7 @@ config:
           version: 1.0.0
           description: gNodeB sim initial configuration
         logger:
-          logLevel: info # how detailed the log will be, values: trace, debug, info, warn, error, fatal, panic
+          logLevel: info # how detailed the log will be, values: debug, info, warn, error, fatal, panic
         configuration:
           runConfigProfilesAtStart: true
           singleInterface: #this will be added thorugh configmap script

--- a/bess-upf/Chart.yaml
+++ b/bess-upf/Chart.yaml
@@ -7,4 +7,4 @@ description: OMEC user plane based on BESS
 name: bess-upf
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.5
+version: 1.1.0

--- a/bess-upf/values.yaml
+++ b/bess-upf/values.yaml
@@ -5,8 +5,8 @@
 images:
   repository: "" #default docker hub
   tags:
-    bess: omecproject/upf-epc-bess:rel-1.4.1
-    pfcpiface: omecproject/upf-epc-pfcpiface:rel-1.4.1
+    bess: omecproject/upf-epc-bess:rel-1.5.0
+    pfcpiface: omecproject/upf-epc-pfcpiface:rel-1.5.0
     tools: busybox:stable
   pullPolicy: IfNotPresent
   # Secrets must be manually created in the namespace.

--- a/omec-sub-provision/Chart.yaml
+++ b/omec-sub-provision/Chart.yaml
@@ -8,4 +8,4 @@ description: Mobile Sim Provisioning services
 name: omec-sub-provision
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.0.1
+version: 1.1.0

--- a/omec-sub-provision/values.yaml
+++ b/omec-sub-provision/values.yaml
@@ -6,7 +6,7 @@ images:
   repository: "" #default docker hub
   tags:
     init: omecproject/pod-init:1.0.0
-    simapp: omecproject/simapp:rel-1.4.1
+    simapp: omecproject/simapp:rel-1.5.0
   pullPolicy: IfNotPresent
 
 resources:
@@ -47,7 +47,6 @@ config:
           # network function
           APP:
             debugLevel: info
-            ReportCaller: false
         configuration:
           provision-network-slice: false
           subscribers:

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 1.0.18
+version: 1.1.0
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -23,22 +23,22 @@ dependencies:
     condition: omec-control-plane.enable4G
 
   - name: omec-sub-provision
-    version: 1.0.1
+    version: 1.1.0
     repository: "file://../omec-sub-provision"
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
-    version: 1.0.13
+    version: 1.1.0
     repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 
   - name: bess-upf
-    version: 1.0.5
+    version: 1.1.0
     repository: "file://../bess-upf"
     alias: omec-user-plane
     condition: omec-user-plane.enable
 
   - name: 5g-ran-sim
-    version: 1.0.3
+    version: 1.1.0
     repository: "file://../5g-ran-sim"
     condition: 5g-ran-sim.enable


### PR DESCRIPTION
This PR includes the following changes:

1. Start using the `upfadapter` image when the upfadapter is deployed instead of using the `smf` image
2. Make the `GIN_MODE` log level configurable. Default value is `release`
3. Update images' tag/version for all of the pods that use images with `zap` logger
4. Remove the `ReportCaller` variable from the `values.yaml` file because the `zap` logger already includes the caller by default
5. Remove variables from the `values.yaml` from components/repos that do not exist/use anymore
6. Create new release for the Helm Charts

The changes proposed in this PR were tested using `aether-onramp`