### PR TITLE
Add initContainer for Kafka and metricfunc and upgrade UPF image tag

### DIFF
--- a/5g-control-plane/Chart.yaml
+++ b/5g-control-plane/Chart.yaml
@@ -10,7 +10,7 @@ description: SD-Core 5G control plane services
 name: 5g-control-plane
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 2.2.3
+version: 2.2.4
 
 dependencies:
   - name: mongodb

--- a/5g-control-plane/templates/deployment-metricfunc.yaml
+++ b/5g-control-plane/templates/deployment-metricfunc.yaml
@@ -37,6 +37,13 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
+      initContainers:
+      {{- if .Values.kafka.deploy }}
+      - name: wait-kafka-module
+        image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}
+        imagePullPolicy: {{ .Values.images.pullPolicy }}
+        command: ['sh', '-c', 'until nc -z kafka-headless 9092; do echo waiting for kafka; sleep 4; done;']
+      {{- end }}
       containers:
       - name: metricfunc
         image: {{ .Values.images.repository }}{{ .Values.images.tags.metricfunc }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -122,6 +122,10 @@ kafka:
       enabled: false
   persistence:
     enabled: false
+  initContainers:
+    - name: wait-for-zookeeper
+      image: busybox
+      command: ['sh', '-c', 'until nc -z sd-core-zookeeper 2181; do echo waiting for zookeeper; sleep 2; done;']
 
 mongodb:
   deploy: true

--- a/bess-upf/Chart.yaml
+++ b/bess-upf/Chart.yaml
@@ -7,4 +7,4 @@ description: OMEC user plane based on BESS
 name: bess-upf
 icon: https://guide.opencord.org/logos/cord.svg
 
-version: 1.2.1
+version: 1.2.2

--- a/bess-upf/values.yaml
+++ b/bess-upf/values.yaml
@@ -5,8 +5,8 @@
 images:
   repository: "" #default docker hub
   tags:
-    bess: omecproject/upf-epc-bess:rel-2.0.1
-    pfcpiface: omecproject/upf-epc-pfcpiface:rel-2.0.1
+    bess: omecproject/upf-epc-bess:rel-2.0.2
+    pfcpiface: omecproject/upf-epc-pfcpiface:rel-2.0.2
     tools: omecproject/pod-init:rel-1.1.2
   pullPolicy: IfNotPresent
   # Secrets must be manually created in the namespace.

--- a/sdcore-helm-charts/Chart.yaml
+++ b/sdcore-helm-charts/Chart.yaml
@@ -10,7 +10,7 @@ name: sd-core
 description: SD-Core control plane services
 icon: https://guide.opencord.org/logos/cord.svg
 type: application
-version: 2.2.3
+version: 2.2.4
 home: https://opennetworking.org/sd-core/
 maintainers:
   - name: SD-Core Support
@@ -28,12 +28,12 @@ dependencies:
     condition: omec-sub-provision.enable
 
   - name: 5g-control-plane
-    version: 2.2.3
+    version: 2.2.4
     repository: "file://../5g-control-plane"
     condition: 5g-control-plane.enable5G
 
   - name: bess-upf
-    version: 1.2.1
+    version: 1.2.2
     repository: "file://../bess-upf"
     alias: omec-user-plane
     condition: omec-user-plane.enable


### PR DESCRIPTION
This PR does the following:
- Add initContainer for Kafka such that it does not crash due to the zookeeper not being up/ready yet
- Add initContainer to metricfunc such that we avoid the initial error due to Kafka crashing
- Use a newer version of the UPF