### PR TITLE
Add Confidential Container Support for 5G Core Network Functions

### DIFF
--- a/5g-control-plane/templates/deployment-amf.yaml
+++ b/5g-control-plane/templates/deployment-amf.yaml
@@ -27,8 +27,17 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if or .Values.confidentialContainers.enabled .Values.confidentialContainers.annotation.enabled }}
+      {{- if not .Values.config.amf.podAnnotations }}
+      annotations:
+      {{- end }}
+{{ include "5g-control-plane.confidential_annotations" . | indent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: amf
+    {{- if .Values.confidentialContainers.enabled }}
+      runtimeClassName: {{ .Values.confidentialContainers.runtimeClassName }}
+    {{- end }}
     {{- if .Values.nodeSelectors.enabled }}
       nodeSelector:
         {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
@@ -38,6 +47,7 @@ spec:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
       initContainers:
+      {{- include "5g-control-plane.attestation_init" . | nindent 6 }}
       {{- if .Values.kafka.deploy }}
       - name: wait-kafka-module
         image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}

--- a/5g-control-plane/templates/deployment-nrf.yaml
+++ b/5g-control-plane/templates/deployment-nrf.yaml
@@ -29,8 +29,17 @@ spec:
         helm.sh/hook-weight: "2"
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if or .Values.confidentialContainers.enabled .Values.confidentialContainers.annotation.enabled }}
+      {{- if not .Values.config.nrf.podAnnotations }}
+      annotations:
+      {{- end }}
+{{ include "5g-control-plane.confidential_annotations" . | indent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: nrf
+    {{- if .Values.confidentialContainers.enabled }}
+      runtimeClassName: {{ .Values.confidentialContainers.runtimeClassName }}
+    {{- end }}
     {{- if .Values.nodeSelectors.enabled }}
       nodeSelector:
         {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
@@ -39,8 +48,9 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
-      {{- if .Values.config.coreDump.enabled }}
       initContainers:
+      {{- include "5g-control-plane.attestation_init" . | nindent 6 }}
+      {{- if .Values.config.coreDump.enabled }}
       {{ tuple "nrf" . | include "5g-control-plane.coredump_init" | indent 6 }}
       {{- end }}
       containers:

--- a/5g-control-plane/templates/deployment-pcf.yaml
+++ b/5g-control-plane/templates/deployment-pcf.yaml
@@ -27,8 +27,17 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if or .Values.confidentialContainers.enabled .Values.confidentialContainers.annotation.enabled }}
+      {{- if not .Values.config.pcf.podAnnotations }}
+      annotations:
+      {{- end }}
+{{ include "5g-control-plane.confidential_annotations" . | indent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: pcf
+    {{- if .Values.confidentialContainers.enabled }}
+      runtimeClassName: {{ .Values.confidentialContainers.runtimeClassName }}
+    {{- end }}
     {{- if .Values.nodeSelectors.enabled }}
       nodeSelector:
         {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
@@ -38,6 +47,7 @@ spec:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
       initContainers:
+      {{- include "5g-control-plane.attestation_init" . | nindent 6 }}
       - name: wait-pcf-module
         image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}
         imagePullPolicy: {{ .Values.images.pullPolicy }}

--- a/5g-control-plane/templates/deployment-smf.yaml
+++ b/5g-control-plane/templates/deployment-smf.yaml
@@ -29,8 +29,17 @@ spec:
         helm.sh/hook-weight: "5"
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.confidentialContainers.enabled }}
+      {{- if not .Values.config.smf.podAnnotations }}
+      annotations:
+      {{- end }}
+{{ include "5g-control-plane.confidential_annotations" . | indent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: smf
+    {{- if .Values.confidentialContainers.enabled }}
+      runtimeClassName: {{ .Values.confidentialContainers.runtimeClassName }}
+    {{- end }}
     {{- if .Values.nodeSelectors.enabled }}
       nodeSelector:
         {{ .Values.nodeSelectors.label }}: {{ .Values.nodeSelectors.value }}
@@ -40,6 +49,7 @@ spec:
 {{ toYaml .Values.images.pullSecrets | indent 8 }}
     {{- end }}
       initContainers:
+      {{- include "5g-control-plane.attestation_init" . | nindent 6 }}
       {{- if .Values.kafka.deploy }}
       - name: wait-kafka-module
         image: {{ .Values.images.repository }}{{ .Values.images.tags.init }}

--- a/5g-control-plane/values.yaml
+++ b/5g-control-plane/values.yaml
@@ -7,6 +7,7 @@ images:
   repository: "" #default docker hub
   tags:
     init: omecproject/pod-init:rel-1.1.2
+    attestation: storytel/alpine-bash-curl:latest
     amf: omecproject/5gc-amf:rel-1.6.5
     nrf: omecproject/5gc-nrf:rel-1.6.3
     smf: omecproject/5gc-smf:rel-2.0.3
@@ -20,6 +21,20 @@ images:
     metricfunc: omecproject/metricfunc:rel-1.6.2
     upfadapter: omecproject/upfadapter:rel-2.0.2
   pullPolicy: IfNotPresent
+
+# Confidential Container Configuration
+confidentialContainers:
+  enabled: false                      # Enable confidential container runtime
+  runtimeClassName: "kata-qemu"       # Runtime class to use
+  annotation:
+    enabled: false                    # Enable kata annotation independently
+    kernelParams: ""                  # Custom kernel parameters, if empty will use default with KBS address
+  attestation:
+    enabled: false                    # Enable attestation init container
+    required: false                   # If true, pod will fail if attestation fails
+    kbsAddress: ""                    # e.g., "http://kbs-service:8080"
+    attestationUrl: "http://127.0.0.1:8006/aa/token?token_type=kbs"
+    timeout: 300                      # Attestation timeout in seconds
 
 nodeSelectors:
   enabled: false


### PR DESCRIPTION
This PR adds support for deploying 5G core network functions in confidential containers using Kata Containers runtime.
Changes:

- Added configurable runtime class support for all core NFs (AMF, SMF, NRF, UDR, UDM, AUSF, PCF, NSSF)
- Added optional attestation init container with configurable timeout
- Added Kata-specific pod annotations with customizable kernel parameters
- Updated _helpers.tpl with reusable templates for confidential container configuration
- Added new configuration section in values.yaml with flexible enable/disable options

- Tested with Kata Containers kata-qemu runtime
- Confirmed backward compatibility with existing deployments

