### PR TITLE
fix(amf): exec the AMF so it receives SIGTERM

### DIFF
--- a/5g-control-plane/templates/bin/_amf-run.sh.tpl
+++ b/5g-control-plane/templates/bin/_amf-run.sh.tpl
@@ -18,4 +18,15 @@ cp /opt/$FILENAME $CFGPATH/$FILENAME
 cat $CFGPATH/$FILENAME
 echo ""
 
-GOTRACEBACK=crash amf -cfg $CFGPATH/$FILENAME
+# exec, so that the AMF replaces this shell and receives the SIGTERM Kubernetes sends on
+# a delete or a rollout. Without it the signal stops at the shell, which does not forward
+# it: the AMF never runs its shutdown sequence - no NRF deregistration, no AMF-unavailable
+# status notification to its peers, no subscription cleanup - and the container ends only
+# when the termination grace period expires and the kubelet sends SIGKILL, so every
+# rollout waits out that period in full.
+#
+# The other run scripts in this chart have the same gap. They are left alone here because
+# turning the signal on makes each NF's shutdown path reachable for the first time, and
+# that path has only been exercised for the AMF, where it turned out to panic
+# (omec-project/amf#811). One at a time, each with its own verification.
+exec env GOTRACEBACK=crash amf -cfg $CFGPATH/$FILENAME


### PR DESCRIPTION
## The defect

`_amf-run.sh.tpl` launches the AMF as a child of the run script, so the container's PID 1 is the shell. Observed on a running deployment:

```
PID   PPID  COMMAND
    1     0 {amf-run.sh} /bin/sh /opt/amf-run.sh
    9     1 amf -cfg /home/amfcfg.yaml
```

Kubernetes sends SIGTERM to PID 1 on a pod delete or a rollout. The shell does not forward it, so the AMF never sees it and never runs its shutdown sequence — no NRF deregistration, no AMF-unavailable status notification to its peers, no subscription cleanup. The container ends only when `terminationGracePeriodSeconds` expires and the kubelet sends SIGKILL, so every rollout waits out that period in full (30 s as deployed here).

## The change

`exec`, so the AMF replaces the shell, becomes PID 1 and receives the signal. `GOTRACEBACK` is passed through unchanged via `env`, since a variable assignment cannot prefix `exec` directly.

Nothing else in the script changes, and the change is invisible to a deployment that never terminates its pods.

## Why the other run scripts are left alone

`ausf`, `metricfunc`, `nrf`, `nssf`, `pcf`, `sctplb`, `smf`, `udm`, `udr`, `upf-adapter` and `webui` all have the same gap — none of the twelve scripts in this chart uses `exec`. They are deliberately not touched here: adding `exec` makes each NF's shutdown path reachable for the first time, and that path has only been exercised for the AMF, where it turned out to panic on any open NGAP association (fixed in omec-project/amf#811, merged). Each of the others deserves its own change with its own verification, rather than eleven paths going live at once.

For the same reason this is sequenced after that fix: with `exec` in place and an AMF that predates it, a pod deletion reaches a shutdown path that aborts instead of completing.

## Verification

`helm lint 5g-control-plane` passes, and `helm template --show-only templates/configmap-amf.yaml` renders the `exec env GOTRACEBACK=crash amf -cfg $CFGPATH/$FILENAME` line into the ConfigMap.
